### PR TITLE
Fix ubuntu20+ compile "error"

### DIFF
--- a/src/behaviourdatabase.cpp
+++ b/src/behaviourdatabase.cpp
@@ -1440,10 +1440,10 @@ int32_t BehaviourDatabase::searchDigitNoLimit(const std::string& message)
 	try {
 		value = std::stoi(message.substr(start, end).c_str());
 	}
-	catch (std::invalid_argument) {
+    catch (std::invalid_argument const&) {
 		return 0;
 	}
-	catch (std::out_of_range) {
+    catch (std::out_of_range const&) {
 		return 0;
 	}
 

--- a/src/behaviourdatabase.cpp
+++ b/src/behaviourdatabase.cpp
@@ -1440,10 +1440,10 @@ int32_t BehaviourDatabase::searchDigitNoLimit(const std::string& message)
 	try {
 		value = std::stoi(message.substr(start, end).c_str());
 	}
-    catch (std::invalid_argument const&) {
+	catch (std::invalid_argument const&) {
 		return 0;
 	}
-    catch (std::out_of_range const&) {
+	catch (std::out_of_range const&) {
 		return 0;
 	}
 


### PR DESCRIPTION
### Fix description
catching exception with const& on BehaviourDatabase::searchDigitNoLimit

### Fix info
The project is configured to compile with warning as errors (```-Werror```) it is failing to compile on ubuntu20+ with the following error
```
[  8%] Building CXX object CMakeFiles/tfs.dir/src/behaviourdatabase.cpp.o
SabrehavenServer/src/behaviourdatabase.cpp: In member function ‘int32_t BehaviourDatabase::searchDigitNoLimit(const string&)’:
SabrehavenServer/src/behaviourdatabase.cpp:1443:17: warning: catching polymorphic type ‘class std::invalid_argument’ by value [-Wcatch-value=]
 1443 |     catch (std::invalid_argument) {
      |                 ^~~~~~~~~~~~~~~~
SabrehavenServer/src/behaviourdatabase.cpp:1446:17: warning: catching polymorphic type ‘class std::out_of_range’ by value [-Wcatch-value=]
 1446 |     catch (std::out_of_range) {
      |                 ^~~~~~~~~~~~
```

An ungraceful solution is to remove the compile options flag ```-Werror``` and it will compile with the warning mentioned above.
A better solution is by simple cataching exceptions with const&, since the catch-block is not modifying it